### PR TITLE
Bump quinn, quinn-udp, rustls and ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ warp = "0.3.5"
 warp-embed = "0.4.0"
 rust-embed = "6"
 mqtt-protocol = { version = "0.12.0", features = ["tokio"] }
-netwatch = "0.2.0"
+pin-project-lite = "0.2.14"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ warp = "0.3.5"
 warp-embed = "0.4.0"
 rust-embed = "6"
 mqtt-protocol = { version = "0.12.0", features = ["tokio"] }
+netwatch = "0.2.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ thiserror = "1.0.37"
 log = "0.4.17"
 env_logger = "0.10.0"
 rand = "0.8.5"
-quinn = "0.9.3"
-quinn-udp = "0.3.2"
+quinn = "0.11.6"
+quinn-udp = "0.5.9"
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
-rustls = { version = "0.20.8", features = ["dangerous_configuration", "quic"] }
+rustls = { version = "0.23.5", features = [] }
 rcgen = "0.10.0"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -42,7 +42,7 @@ cryptoxide = { version = "0.4.4", default-features = false, features = [
 ] }
 hex = "0.4.3"
 key-to-animal = "0.0.1"
-ring = "0.16.20"
+ring = "0.17"
 speedometer = "0.2.2"
 stunclient = "0.4.1"
 lru = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ rand = "0.8.5"
 quinn = "0.11.6"
 quinn-udp = "0.5.9"
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
-rustls = { version = "0.23.5", features = [] }
+rustls = { version = "0.23.5", features = ["ring"] }
+rustls-pki-types = "1.10.1"
 rcgen = "0.10.0"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -115,8 +115,7 @@ impl PeerDiscovery {
         // error
         let local_connection_details = stun_test(&raw_socket).await?;
 
-        let (socket, hole_puncher) =
-            PunchingUdpSocket::bind(SocketAddr::new(my_local_ip, 0)).await?;
+        let (socket, hole_puncher) = PunchingUdpSocket::bind(raw_socket).await?;
 
         let addr = socket.local_addr()?;
 

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -115,7 +115,8 @@ impl PeerDiscovery {
         // error
         let local_connection_details = stun_test(&raw_socket).await?;
 
-        let (socket, hole_puncher) = PunchingUdpSocket::bind(raw_socket).await?;
+        let (socket, hole_puncher) =
+            PunchingUdpSocket::bind(SocketAddr::new(my_local_ip, 0)).await?;
 
         let addr = socket.local_addr()?;
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -297,7 +297,7 @@ async fn make_read_request(
     let (mut send, recv) = connection.open_bi().await?;
     let buf = serialize(&request)?;
     send.write_all(&buf).await?;
-    send.finish().await?;
+    send.finish()?;
     Ok(recv)
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -108,7 +108,7 @@ impl Rpc {
                     output.write_all(&buf).await?;
                     debug!("Written ls response");
                 }
-                output.finish().await?;
+                output.finish()?;
                 Ok(())
             }
             Err(error) => {
@@ -209,7 +209,7 @@ impl Uploader {
                     output.write_all(&buf[..n]).await?;
                     debug!("Uploaded {} bytes of {}", bytes_read, size);
                 }
-                output.finish().await?;
+                output.finish()?;
                 Ok(())
             }
             Err(rpc_error) => send_error(rpc_error, output).await,
@@ -275,7 +275,7 @@ impl Uploader {
 async fn send_error(error: RpcError, mut output: quinn::SendStream) -> Result<(), RpcError> {
     // TODO send serialised version of the error
     output.write_all(&[0]).await?;
-    output.finish().await?;
+    output.finish()?;
     Err(error)
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -298,6 +298,8 @@ pub enum RpcError {
     ChannelClosed,
     #[error("Cannot convert to u64")]
     U64ConvertError,
+    #[error("QUIC stream closed")]
+    ClosedStream(#[from] quinn::ClosedStream),
 }
 
 // fn create_error_stream(err: RpcError) -> Box<dyn Stream<Item = response::Response> + Send> {


### PR DESCRIPTION
Stuck on this - can't figure out how to implement [`AsyncUdpSocket::create_io_poller`](https://docs.rs/quinn/0.11.5/quinn/trait.AsyncUdpSocket.html#tymethod.create_io_poller) for quinn 0.11.6 

Iroh [does this](https://github.com/n0-computer/iroh/blob/9275d22dea6c14a1a2090be1985fd97a7de4801d/iroh/src/magicsock/udp_conn.rs#L49) using their [netwatch](https://docs.rs/netwatch) crate - but it depends on forks of quinn and quinn-udp.

ChainSafe/js-libp2p-quic does: https://github.com/ChainSafe/js-libp2p-quic/blob/676650e8cb130f7b3b4c5852e0ba1464ca3b132e/rust/socket.rs#L51 using pin_project_lite but i could not get this to work here.