### PR TITLE
Misc improvements to web-ui

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
 
+    - name: Check web-ui mock mode
+      run: cargo check --locked --manifest-path web-ui/Cargo.toml --features mock-ui
+
     - name: Set up Firefox
       uses: browser-actions/setup-firefox@latest
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ test-web-ui:
     - chmod +x /usr/local/bin/geckodriver
     - rustup target add wasm32-unknown-unknown
     - cargo install --force wasm-bindgen-cli --version 0.2.117
+    - cargo check --manifest-path web-ui/Cargo.toml --features mock-ui
     - cargo test --manifest-path web-ui/Cargo.toml --target wasm32-unknown-unknown --lib
 
 # - cargo install cargo-audit

--- a/web-ui/src/file.rs
+++ b/web-ui/src/file.rs
@@ -284,13 +284,39 @@ pub fn File(file: File, is_shared: bool, context: FileDisplayContext) -> impl In
 pub enum DownloadStatus {
     Nothing,
     Requested(u32),
-    Downloading { bytes_read: u64, request_id: u32 },
+    Downloading {
+        bytes_read: u64,
+        request_id: u32,
+    },
     Uploading {
         bytes_read: u64,
         total_size: u64,
         speed: u64,
     },
     Downloaded(u32),
+}
+
+impl DownloadStatus {
+    pub fn merge_request_snapshot(&self, incoming: Self) -> Self {
+        match (self, &incoming) {
+            (
+                DownloadStatus::Downloading {
+                    request_id: current_id,
+                    ..
+                },
+                DownloadStatus::Requested(incoming_id),
+            ) if current_id == incoming_id => self.clone(),
+            (DownloadStatus::Downloaded(current_id), DownloadStatus::Requested(incoming_id))
+            | (
+                DownloadStatus::Downloaded(current_id),
+                DownloadStatus::Downloading {
+                    request_id: incoming_id,
+                    ..
+                },
+            ) if current_id == incoming_id => self.clone(),
+            _ => incoming,
+        }
+    }
 }
 
 /// Show progress when currently downloading
@@ -316,6 +342,63 @@ pub fn DownloadingFile(bytes_read: u64, size: Option<u64>) -> impl IntoView {
                 _ => format!("Downloading {}...", display_bytes(bytes_read)),
             }}
         </span>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DownloadStatus;
+
+    #[test]
+    fn request_snapshot_does_not_downgrade_active_download() {
+        let current = DownloadStatus::Downloading {
+            bytes_read: 1024,
+            request_id: 42,
+        };
+
+        assert_eq!(
+            current.merge_request_snapshot(DownloadStatus::Requested(42)),
+            current
+        );
+    }
+
+    #[test]
+    fn request_snapshot_can_complete_active_download() {
+        let current = DownloadStatus::Downloading {
+            bytes_read: 1024,
+            request_id: 42,
+        };
+
+        assert_eq!(
+            current.merge_request_snapshot(DownloadStatus::Downloaded(42)),
+            DownloadStatus::Downloaded(42)
+        );
+    }
+
+    #[test]
+    fn request_snapshot_for_new_request_can_replace_old_status() {
+        let current = DownloadStatus::Downloading {
+            bytes_read: 1024,
+            request_id: 42,
+        };
+
+        assert_eq!(
+            current.merge_request_snapshot(DownloadStatus::Requested(43)),
+            DownloadStatus::Requested(43)
+        );
+    }
+
+    #[test]
+    fn stale_progress_does_not_downgrade_completed_download() {
+        let current = DownloadStatus::Downloaded(42);
+
+        assert_eq!(
+            current.merge_request_snapshot(DownloadStatus::Downloading {
+                bytes_read: 1024,
+                request_id: 42,
+            }),
+            current
+        );
     }
 }
 

--- a/web-ui/src/lib.rs
+++ b/web-ui/src/lib.rs
@@ -24,10 +24,10 @@ use leptos::{prelude::*, task::spawn_local};
 use leptos_router::components::Router;
 use log::{debug, warn};
 use requests::Requests;
-use uploads::Uploads;
 use std::collections::{BTreeMap, HashSet};
 use thaw::*;
 use ui_messages::UiDownloadRequest;
+use uploads::Uploads;
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -139,9 +139,15 @@ impl UiClient {
 
     pub async fn connect(&self, announce_address: String) -> Result<(), AppError> {
         match self {
-            UiClient::Real(client) => client.connect(announce_address).await.map_err(AppError::from),
+            UiClient::Real(client) => client
+                .connect(announce_address)
+                .await
+                .map_err(AppError::from),
             #[cfg(feature = "mock-ui")]
-            UiClient::Mock(client) => client.connect(announce_address).await.map_err(AppError::from),
+            UiClient::Mock(client) => client
+                .connect(announce_address)
+                .await
+                .map_err(AppError::from),
         }
     }
 
@@ -327,8 +333,9 @@ impl AppContext {
                 Ok(id) => {
                     debug!("Download requested with id: {}", id);
                     let cached_file = files.with_untracked(|files| files.get(&peer_path).cloned());
-                    let total_size =
-                        cached_file.as_ref().map_or(0, |file| file.size.unwrap_or_default());
+                    let total_size = cached_file
+                        .as_ref()
+                        .map_or(0, |file| file.size.unwrap_or_default());
                     let request = UiDownloadRequest {
                         path: peer_path.path.clone(),
                         peer_name: peer_path.peer_name.clone(),
@@ -457,7 +464,9 @@ impl AppContext {
                                                     file.size = Some(entry.size);
                                                     file.is_dir = Some(entry.is_dir);
                                                 })
-                                                .or_insert_with(|| File::from_entry(entry, peer_name.clone()));
+                                                .or_insert_with(|| {
+                                                    File::from_entry(entry, peer_name.clone())
+                                                });
                                         }
                                     });
                                 }
@@ -530,8 +539,11 @@ impl AppContext {
                                         path: upper_bound,
                                     },
                                 ) {
-                                    // TODO only set this to requested if...
-                                    file.download_status.set(download_status.clone());
+                                    let merged = file
+                                        .download_status
+                                        .get_untracked()
+                                        .merge_request_snapshot(download_status.clone());
+                                    file.download_status.set(merged);
                                 }
                             }
                         });
@@ -561,7 +573,9 @@ impl AppContext {
                             let request_path = request.path.clone();
                             let is_dir_request = requested_files.iter().any(|requested_file| {
                                 requested_file.path != request_path
-                                    && requested_file.path.starts_with(&format!("{}/", request_path))
+                                    && requested_file
+                                        .path
+                                        .starts_with(&format!("{}/", request_path))
                             }) || (requested_files.len() > 1);
                             for requested_file in requested_files {
                                 let download_status = if requested_file.downloaded {
@@ -576,9 +590,11 @@ impl AppContext {
                                 files
                                     .entry(peer_path)
                                     .and_modify(|file| {
-                                        // TODO this should not clobber if file is in
-                                        // downloading state
-                                        file.download_status.set(download_status.clone());
+                                        let merged = file
+                                            .download_status
+                                            .get_untracked()
+                                            .merge_request_snapshot(download_status.clone());
+                                        file.download_status.set(merged);
                                         file.size = Some(requested_file.size);
                                     })
                                     .or_insert(File {

--- a/web-ui/src/mock.rs
+++ b/web-ui/src/mock.rs
@@ -167,6 +167,7 @@ impl MockClient {
             request_id: 2000,
             timestamp: Duration::from_secs(1_710_000_000),
             peer_name: "asphericKingCrab".to_string(),
+            is_dir: false,
         }])])
         .boxed_local())
     }

--- a/web-ui/src/peer.rs
+++ b/web-ui/src/peer.rs
@@ -222,15 +222,20 @@ pub fn Peers(
 
     let copy_to_clipboard = move |_| {
         wasm_bindgen_futures::spawn_local(async move {
-            let window = web_sys::window().unwrap();
+            let Some(window) = web_sys::window() else {
+                log::warn!("Cannot copy announce address: window is unavailable");
+                return;
+            };
             let clipboard = window.navigator().clipboard();
             let promise = clipboard.write_text(
                 &announce_address
                     .get_untracked()
                     .unwrap_or("Cannot get signal".to_string()),
             );
-            let _result = wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
-            log::info!("Copied to clipboard");
+            match wasm_bindgen_futures::JsFuture::from(promise).await {
+                Ok(_) => log::info!("Copied to clipboard"),
+                Err(err) => log::warn!("Cannot copy announce address: {:?}", err),
+            }
         });
     };
 

--- a/web-ui/src/search.rs
+++ b/web-ui/src/search.rs
@@ -21,14 +21,13 @@ pub fn Search(search_results: ReadSignal<Vec<PeerPath>>) -> impl IntoView {
 
     let files = app_context.get_files;
     let search_results_iter = move || {
-        // Calling .get() clones - we should ideally use .with()
-        let search_results = search_results.get();
-        search_results.into_iter().filter_map(move |peer_path| {
-            let files = files.get();
-            match files.get(&peer_path) {
-                Some(file) => Some(file.clone()),
-                None => None,
-            }
+        search_results.with(|search_results| {
+            files.with(|files| {
+                search_results
+                    .iter()
+                    .filter_map(|peer_path| files.get(peer_path).cloned())
+                    .collect::<Vec<File>>()
+            })
         })
     };
 

--- a/web-ui/src/transfers.rs
+++ b/web-ui/src/transfers.rs
@@ -15,19 +15,16 @@ pub fn Transfers(
     uploads: ReadSignal<Uploads>,
 ) -> impl IntoView {
     let wishlist = move || {
-        requests
-            .get()
-            .iter()
-            .filter_map(|((_timestamp, _id), peer_path)| {
-                let files = files.get();
-                match files.get(peer_path) {
-                    Some(file) => Some(file.clone()),
-                    None => None,
-                }
+        requests.with(|requests| {
+            files.with(|files| {
+                requests
+                    .iter()
+                    .filter_map(|((_timestamp, _id), peer_path)| files.get(peer_path).cloned())
+                    .collect::<Vec<File>>()
             })
-            .collect::<Vec<File>>()
+        })
     };
-    let uploads_list = move || uploads.get().iter().cloned().collect::<Vec<_>>();
+    let uploads_list = move || uploads.with(|uploads| uploads.iter().cloned().collect::<Vec<_>>());
 
     view! {
         <h2 class="text-xl">"Transfers"</h2>

--- a/web-ui/src/ws.rs
+++ b/web-ui/src/ws.rs
@@ -21,7 +21,8 @@ impl WebsocketService {
         set_error_message: WriteSignal<HashSet<AppError>>,
     ) -> anyhow::Result<(Self, Receiver<UiEvent>)> {
         let mut url = url.join("ws")?;
-        url.set_scheme("ws")
+        let ws_scheme = if url.scheme() == "https" { "wss" } else { "ws" };
+        url.set_scheme(ws_scheme)
             .map_err(|_| anyhow!("Cannot set url scheme"))?;
 
         let (out_tx, out_rx) = channel::<UiEvent>(1024);

--- a/web-ui/style.css
+++ b/web-ui/style.css
@@ -6,6 +6,8 @@
 	--text: #17202a;
 	--text-muted: #4f5b67;
 	--border: #dde3ea;
+	--file-meta-width: 190px;
+	--transfer-meta-width: 220px;
 	--shadow: 0 10px 30px rgba(16, 24, 40, 0.08);
 	--radius: 14px;
 	--radius-sm: 10px;
@@ -65,10 +67,6 @@ body {
 .tab-list .thaw-flex {
 	flex-wrap: wrap;
 	row-gap: 6px;
-}
-
-.tab-list .thaw-flex {
-	flex-wrap: wrap;
 	gap: 8px;
 }
 
@@ -130,6 +128,7 @@ pre {
 	gap: 12px;
 	margin-bottom: 8px;
 }
+
 .file-table,
 .search-table,
 .transfer-table {
@@ -170,8 +169,8 @@ pre {
 }
 
 .file-table .thaw-table-cell:last-child {
-	width: 190px;
-	min-width: 190px;
+	width: var(--file-meta-width);
+	min-width: var(--file-meta-width);
 	text-align: right;
 	padding-right: 10px;
 	vertical-align: top;
@@ -229,12 +228,6 @@ pre {
 	padding-bottom: 8px;
 }
 
-.transfer-request-status-detail {
-	margin-left: auto;
-	min-width: min(260px, 100%);
-	text-align: right;
-}
-
 .transfer-request-files {
 	margin-top: 10px;
 }
@@ -265,13 +258,9 @@ pre {
 }
 
 .transfer-table .thaw-table-cell:last-child {
-	width: 220px;
-	min-width: 220px;
+	width: var(--transfer-meta-width);
+	min-width: var(--transfer-meta-width);
 	vertical-align: top;
-}
-
-.upload-file-name {
-	margin: 0;
 }
 
 .transfer-table .thaw-progress-bar {
@@ -286,14 +275,6 @@ pre {
 
 .error-stack {
 	margin-bottom: 10px;
-}
-
-.hdp-header__menu-mobile {
-	display: none !important;
-}
-
-.hdp-header__right-btn .thaw-select {
-	width: 60px;
 }
 
 .known-peers-list {
@@ -357,9 +338,9 @@ pre {
 }
 
 @media screen and (max-width: 720px) {
-	.file-table .thaw-table-cell:last-child {
-		width: 140px;
-		min-width: 140px;
+	:root {
+		--file-meta-width: 140px;
+		--transfer-meta-width: 160px;
 	}
 
 	.main {
@@ -386,15 +367,11 @@ pre {
 	.tab-list {
 		overflow-x: auto;
 	}
-
-	.transfer-table .thaw-table-cell:last-child {
-		width: 160px;
-		min-width: 160px;
-	}
 }
 
 @media screen and (max-width: 600px) {
-	body, html {
+	html,
+	body {
 		padding: 0 4px;
 	}
 
@@ -451,14 +428,5 @@ pre {
 	.form-row > .thaw-button,
 	.form-row > button {
 		width: 100%;
-	}
-}
-
-@media screen and (max-width: 1200px) {
-	.hdp-header__right-btn {
-		display: none !important;
-	}
-	.hdp-header__menu-mobile {
-		display: inline-block !important;
 	}
 }


### PR DESCRIPTION
Some small fixes to the front end:
- Added CI coverage for web-ui mock mode so mock-ui stays compile-safe.
- Fixed mock download request data to include is_dir.
- Preserved active/completed download UI state when request snapshots arrive out of order.
- Added unit coverage for download status merge behavior.
- Switched websocket connections to wss:// when the page is served over HTTPS.
- Made clipboard copy failures non-fatal and logged instead of panicking.
- Reduced unnecessary signal cloning in search and transfers views.
- Cleaned up responsive CSS for file/transfer metadata widths and header layout.