### PR TITLE
Switch from bincode to bincode-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
+ "bincode_derive-next",
  "serde",
+ "unty-next",
+]
+
+[[package]]
+name = "bincode_derive-next"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af389a025376dbbe728c43dfa5c08f866116c0b62627787c21ca1c69e2b8dec"
+dependencies = [
+ "virtue-next",
 ]
 
 [[package]]
@@ -861,7 +872,6 @@ dependencies = [
  "async-stream",
  "async-walkdir",
  "axum",
- "bincode",
  "bytecodec",
  "bytes",
  "clap",
@@ -900,7 +910,7 @@ name = "harddrive-party-shared"
 version = "0.0.2"
 dependencies = [
  "base64 0.22.1",
- "bincode",
+ "bincode-next",
  "bytes",
  "futures",
  "reqwest",
@@ -2695,6 +2705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2745,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue-next"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5208a9710a6ca1c2da0d64289a5dcca13deb05afdedf651f4e11bcd9fc53eb"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ quinn-udp = "0.5.14"
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "signal"] }
 rustls = { version = "0.23.5", features = ["ring"], default-features = false }
 rcgen = "0.10.0"
-bincode = "1.3.3"
 clap = { version = "4.3.0", features = ["derive"] }
 colored = "2.0.0"
 mdns-sd = "0.5.10"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Peers connect to each other using [QUIC](https://en.wikipedia.org/wiki/QUIC), wi
 - `Read` - for downloading a file, or portion of a file. 
 - `AnnouncePeer` - for passing on connection details of another peer.
 
-These [wire messages](./shared/src/wire_messages.rs) are serialized with [bincode](https://docs.rs/bincode).
+These [wire messages](./shared/src/wire_messages.rs) are serialized with [bincode-next](https://docs.rs/bincode-next) using the bincode 1-compatible legacy configuration.
 
 ### Shared files
 
@@ -129,7 +129,7 @@ The UI server exposes:
   - `POST /api/close`
 - Static access to downloaded files under `/downloads/*`
 
-Most `/api/*` payloads are bincode-encoded rather than JSON (see [`shared/src/client/mod.rs`](./shared/src/client/mod.rs)).
+Most `/api/*` payloads use the bincode wire format rather than JSON (see [`shared/src/client/mod.rs`](./shared/src/client/mod.rs)).
 
 ### Peer names
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["peer-to-peer", "filesharing", "file-sharing", "p2p"]
 thiserror = "1.0.37"
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3.25"
-bincode = "1.3.3"
+bincode-next = { version = "2.1.0", features = ["serde"] }
 reqwest = { version = "0.12.15", default-features = false, features = [
   "stream",
 ] }

--- a/shared/src/client/events.rs
+++ b/shared/src/client/events.rs
@@ -1,5 +1,4 @@
-use crate::{client::ClientError, ui_messages::UiEvent};
-use bincode::deserialize;
+use crate::{client::ClientError, codec::deserialize, ui_messages::UiEvent};
 use futures::{stream::SplitStream, Stream, StreamExt};
 use reqwest::Url;
 use std::pin::Pin;

--- a/shared/src/client/mod.rs
+++ b/shared/src/client/mod.rs
@@ -6,10 +6,10 @@ pub use events::EventStream;
 
 use crate::{
     announce_address::{AnnounceAddress, AnnounceAddressDecodeError},
+    codec::{deserialize, serialize},
     ui_messages::{FilesQuery, Info, PeerPath, UiDownloadRequest, UiRequestedFile, UiServerError},
     wire_messages::{IndexQuery, LsResponse, ReadQuery},
 };
-use bincode::{deserialize, serialize};
 use bytes::{Buf, Bytes, BytesMut};
 use futures::Stream;
 use reqwest::{Response, Url};
@@ -180,7 +180,7 @@ impl Client {
             return Err(ClientError::from_response(res).await);
         }
 
-        Ok(bincode::deserialize(&res.bytes().await?)?)
+        Ok(deserialize(res.bytes().await?)?)
     }
 
     /// GET `/known-peers`
@@ -200,7 +200,7 @@ impl Client {
             return Err(ClientError::from_response(res).await);
         }
 
-        let encoded: Vec<String> = bincode::deserialize(&res.bytes().await?)?;
+        let encoded: Vec<String> = deserialize(res.bytes().await?)?;
         encoded
             .into_iter()
             .map(AnnounceAddress::from_string)
@@ -406,8 +406,14 @@ pub enum ClientError {
     ServerError(#[from] UiServerError),
 }
 
-impl From<bincode::Error> for ClientError {
-    fn from(value: bincode::Error) -> Self {
+impl From<crate::codec::EncodeError> for ClientError {
+    fn from(value: crate::codec::EncodeError) -> Self {
+        ClientError::Serialization(value.to_string())
+    }
+}
+
+impl From<crate::codec::DecodeError> for ClientError {
+    fn from(value: crate::codec::DecodeError) -> Self {
         ClientError::Serialization(value.to_string())
     }
 }

--- a/shared/src/codec.rs
+++ b/shared/src/codec.rs
@@ -1,0 +1,28 @@
+//! Wrappers exposing bincode-next codec with bincode 1 legacy format
+use serde::{de::DeserializeOwned, Serialize};
+
+pub use bincode_next::error::{DecodeError, EncodeError};
+
+/// Wraps bincode-next encoder
+pub fn serialize<T>(value: &T) -> Result<Vec<u8>, EncodeError>
+where
+    T: Serialize,
+{
+    bincode_next::serde::encode_to_vec(value, bincode_next::config::legacy())
+}
+
+/// Wraps bincode-next decoder
+pub fn deserialize<T>(bytes: impl AsRef<[u8]>) -> Result<T, DecodeError>
+where
+    T: DeserializeOwned,
+{
+    let (value, bytes_read) =
+        bincode_next::serde::decode_from_slice(bytes.as_ref(), bincode_next::config::legacy())?;
+    if bytes_read != bytes.as_ref().len() {
+        return Err(DecodeError::OtherString(format!(
+            "trailing bytes after bincode message: {}",
+            bytes.as_ref().len() - bytes_read
+        )));
+    }
+    Ok(value)
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,5 @@
 mod announce_address;
 pub mod client;
+pub mod codec;
 pub mod ui_messages;
 pub mod wire_messages;

--- a/src/connections/known_peers.rs
+++ b/src/connections/known_peers.rs
@@ -1,5 +1,5 @@
 //! Tracks known peers for certificate checking and reconnecting
-use harddrive_party_shared::wire_messages::AnnounceAddress;
+use harddrive_party_shared::{codec, wire_messages::AnnounceAddress};
 
 use crate::errors::UiServerErrorWrapper;
 
@@ -16,7 +16,7 @@ impl KnownPeers {
 
     /// Add a peer who we know of through one of the discovery methods
     pub fn add_peer(&self, announce_address: &AnnounceAddress) -> Result<(), UiServerErrorWrapper> {
-        let connection_details = bincode::serialize(&announce_address.connection_details)?;
+        let connection_details = codec::serialize(&announce_address.connection_details)?;
         self.db
             .insert(announce_address.name.as_bytes(), connection_details)?;
         Ok(())
@@ -34,7 +34,7 @@ impl KnownPeers {
 
             Some(AnnounceAddress {
                 name: String::from_utf8(k.to_vec()).ok()?,
-                connection_details: bincode::deserialize(&v).ok()?,
+                connection_details: codec::deserialize(&v).ok()?,
             })
         }))
     }

--- a/src/connections/rpc.rs
+++ b/src/connections/rpc.rs
@@ -10,9 +10,9 @@ use crate::{
     ui_messages::{UiEvent, UploadInfo},
     SharedState,
 };
-use bincode::{deserialize, serialize};
-use harddrive_party_shared::wire_messages::{
-    AnnouncePeer, IndexQuery, LsResponse, LsResponseError, ReadQuery, Request,
+use harddrive_party_shared::{
+    codec::{deserialize, serialize, DecodeError},
+    wire_messages::{AnnouncePeer, IndexQuery, LsResponse, LsResponseError, ReadQuery, Request},
 };
 use log::{debug, error, info, warn};
 use quinn::WriteError;
@@ -94,7 +94,7 @@ impl Rpc {
 
     /// Handle a request
     pub async fn request(&self, buf: Vec<u8>, output: quinn::SendStream, peer_name: String) {
-        let request: Result<Request, Box<bincode::ErrorKind>> = deserialize(&buf);
+        let request: Result<Request, DecodeError> = deserialize(&buf);
         match request {
             Ok(req) => {
                 debug!("Got request from peer {req:?}");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -83,8 +83,14 @@ impl From<sled::Error> for UiServerErrorWrapper {
     }
 }
 
-impl From<Box<bincode::ErrorKind>> for UiServerErrorWrapper {
-    fn from(error: Box<bincode::ErrorKind>) -> UiServerErrorWrapper {
+impl From<harddrive_party_shared::codec::EncodeError> for UiServerErrorWrapper {
+    fn from(error: harddrive_party_shared::codec::EncodeError) -> UiServerErrorWrapper {
+        UiServerErrorWrapper(UiServerError::Db(error.to_string()))
+    }
+}
+
+impl From<harddrive_party_shared::codec::DecodeError> for UiServerErrorWrapper {
+    fn from(error: harddrive_party_shared::codec::DecodeError) -> UiServerErrorWrapper {
         UiServerErrorWrapper(UiServerError::Db(error.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,11 @@ use crate::{
     wishlist::{DownloadRequest, RequestedFile, WishList},
 };
 use async_stream::try_stream;
-use bincode::serialize;
 use futures::{pin_mut, StreamExt};
-use harddrive_party_shared::wire_messages::{IndexQuery, LsResponse};
+use harddrive_party_shared::{
+    codec::{deserialize, serialize},
+    wire_messages::{IndexQuery, LsResponse},
+};
 use log::{debug, error, warn};
 use quinn::RecvStream;
 use rand::{rngs::OsRng, Rng};
@@ -339,7 +341,7 @@ pub async fn process_length_prefix(
             let mut msg_buf = vec![Default::default(); length_usize];
             match recv.read_exact(&mut msg_buf).await {
                 Ok(()) => {
-                    let ls_response: LsResponse = bincode::deserialize(&msg_buf)?;
+                    let ls_response: LsResponse = deserialize(&msg_buf)?;
                     yield ls_response;
                 }
                 Err(_) => {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -12,9 +12,11 @@ use crate::{
     wishlist::{DownloadRequest, RequestedFile, WishList},
 };
 use anyhow::anyhow;
-use bincode::serialize;
 use futures::{pin_mut, StreamExt};
-use harddrive_party_shared::wire_messages::{AnnounceAddress, Entry};
+use harddrive_party_shared::{
+    codec::serialize,
+    wire_messages::{AnnounceAddress, Entry},
+};
 use key_to_animal::key_to_name;
 use log::{debug, error, warn};
 use lru::LruCache;

--- a/src/ui_server/api.rs
+++ b/src/ui_server/api.rs
@@ -17,6 +17,7 @@ use axum::{
 use bytes::{BufMut, BytesMut};
 use futures::{channel::mpsc, pin_mut, SinkExt, StreamExt};
 use harddrive_party_shared::{
+    codec::serialize,
     ui_messages::{Info, PeerPath, UiDownloadRequest, UiRequestedFile},
     wire_messages::ReadQuery,
 };
@@ -95,7 +96,7 @@ pub async fn post_files(
                 for entries in responses {
                     let ls_response = LsResponse::Success(entries);
                     if let Ok(serialized_res) =
-                        bincode::serialize(&Ok::<(LsResponse, String), UiServerError>((
+                        serialize(&Ok::<(LsResponse, String), UiServerError>((
                             ls_response,
                             peer_name.to_string(),
                         )))
@@ -137,12 +138,10 @@ pub async fn post_files(
                         cached_entries.push(entries.clone());
                     }
                 }
-                if let Ok(serialized_res) =
-                    bincode::serialize(&Ok::<(LsResponse, String), UiServerError>((
-                        ls_response,
-                        peer_name_clone.to_string(),
-                    )))
-                {
+                if let Ok(serialized_res) = serialize(&Ok::<(LsResponse, String), UiServerError>((
+                    ls_response,
+                    peer_name_clone.to_string(),
+                ))) {
                     let serialized_res = create_length_prefixed_message(&serialized_res);
                     if response_tx.send(serialized_res).await.is_err() {
                         warn!("Response channel closed");
@@ -331,7 +330,7 @@ where
     let (mut response_tx, response_rx) = mpsc::channel(256);
     tokio::spawn(async move {
         for res in input_iterator {
-            match bincode::serialize(&Ok::<T, UiServerError>(res)) {
+            match serialize(&Ok::<T, UiServerError>(res)) {
                 Ok(serialized_res) => {
                     let serialized_res = create_length_prefixed_message(&serialized_res);
                     if response_tx.send(serialized_res).await.is_err() {

--- a/src/ui_server/mod.rs
+++ b/src/ui_server/mod.rs
@@ -22,6 +22,7 @@ use axum::{
     routing::{any, delete, get, post, put},
     Router,
 };
+use harddrive_party_shared::codec;
 use log::error;
 use mime_guess::from_path;
 use rust_embed::RustEmbed;
@@ -130,7 +131,7 @@ where
                 )
             })?;
 
-        let obj = bincode::deserialize::<T>(&bytes).map_err(|_| {
+        let obj = codec::deserialize::<T>(&bytes).map_err(|_| {
             (
                 StatusCode::BAD_REQUEST,
                 "Failed to decode bincode body".into(),
@@ -146,7 +147,7 @@ where
     T: Serialize,
 {
     fn into_response(self) -> Response<Body> {
-        match bincode::serialize(&self.0) {
+        match codec::serialize(&self.0) {
             Ok(bytes) => (
                 [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
                 bytes,

--- a/src/ui_server/ws.rs
+++ b/src/ui_server/ws.rs
@@ -1,7 +1,7 @@
 //! Websocket server for sending events to UI
 use crate::SharedState;
 use axum::extract::ws::{Message, WebSocket};
-use bincode::serialize;
+use harddrive_party_shared::codec::serialize;
 use log::{error, warn};
 
 pub async fn handle_socket(shared_state: SharedState, mut socket: WebSocket) {

--- a/web-ui/Cargo.lock
+++ b/web-ui/Cargo.lock
@@ -117,12 +117,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
+ "bincode_derive-next",
  "serde",
+ "unty-next",
+]
+
+[[package]]
+name = "bincode_derive-next"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af389a025376dbbe728c43dfa5c08f866116c0b62627787c21ca1c69e2b8dec"
+dependencies = [
+ "virtue-next",
 ]
 
 [[package]]
@@ -628,7 +639,7 @@ name = "harddrive-party-shared"
 version = "0.0.2"
 dependencies = [
  "base64",
- "bincode",
+ "bincode-next",
  "bytes",
  "futures",
  "reqwest",
@@ -642,7 +653,6 @@ name = "harddrive-party-web-ui"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "bincode",
  "console_error_panic_hook",
  "console_log",
  "futures",
@@ -2574,6 +2584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2635,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue-next"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5208a9710a6ca1c2da0d64289a5dcca13deb05afdedf651f4e11bcd9fc53eb"
 
 [[package]]
 name = "walkdir"

--- a/web-ui/Cargo.toml
+++ b/web-ui/Cargo.toml
@@ -21,7 +21,6 @@ leptos_meta = "0.7.7"
 reqwasm = "0.5.0"
 futures = "0.3.26"
 wasm-bindgen-futures = "0.4.34"
-bincode = "1.3.3"
 rand = "0.8.5"
 getrandom = { version = "0.2.8", features = ["js"] }
 pretty-bytes-rust = "0.1.0"

--- a/web-ui/src/ws.rs
+++ b/web-ui/src/ws.rs
@@ -1,11 +1,10 @@
 use crate::AppError;
 use anyhow::anyhow;
-use bincode::deserialize;
 use futures::{
     channel::mpsc::{channel, Receiver},
     SinkExt, StreamExt,
 };
-use harddrive_party_shared::ui_messages::UiEvent;
+use harddrive_party_shared::{codec::deserialize, ui_messages::UiEvent};
 use leptos::prelude::*;
 use log::{debug, error, warn};
 use reqwasm::websocket::{futures::WebSocket, Message};


### PR DESCRIPTION
Bincode is no longer maintained.  This switches to a compatible actively maintained fork, bincode-next.

We still use the bincode-1 legacy format to avoid a protocol-breaking change, but at some point we could switch to bincode 2.